### PR TITLE
Add sourcemap support and tsconfig.json relative to basepath

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,11 @@ Here is a full featured example with all options that you can use to configure t
 // karma.conf.js 
 module.exports = function(config) {
   config.set({
+    files: [
+      '**/*.ts'   // Preprocessor will convert Typescript to Javascript
+    ],
     preprocessors: {
-      '**/*.ts': ['typescript']
+      '**/*.ts': ['typescript', 'sourcemap']   // Use karma-sourcemap-loader
     },
     typescriptPreprocessor: {
       // options passed to typescript compiler 
@@ -39,7 +42,10 @@ module.exports = function(config) {
       compilerOptions: { // *optional
         removeComments: false
       },
-      ignorePath: function(path){ // ignore all files that ends with .d.ts (this files will not be served)
+      // Options passed to gulp-sourcemaps to create sourcemaps
+      sourcemapOptions: {includeContent: true, sourceRoot: '/src'},
+      // ignore all files that ends with .d.ts (this files will not be served)
+      ignorePath: function(path){ 
        return /\.d\.ts$/.test(path);
       },
       // transforming the filenames 
@@ -89,6 +95,9 @@ As we use gulp-typescript to transpiler typescript code, we have the same unsupo
  - project - See "Using tsconfig.json".
  - 
 And obvious ones: help, version
+
+## Sourcemaps
+Transpiling with gulp-typescript requires the use of gulp-sourcemaps to create sourcemaps.
 
 ## Plugin Options
 
@@ -159,6 +168,10 @@ function(path){
 }
 
 ```
+
+### sourcemapOptions: any
+
+Specify ``gulp-sourcemaps`` write options. Inline sourcemaps are the easiest to configure for testing. For more info [see gulp-sourcemaps write options](https://www.npmjs.com/package/gulp-sourcemaps).
 
 ### compilerOptions: any
 

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = (function (testMode) {
 
     var _currentState      = state.idle;
 
-    function factoryTypeScriptPreprocessor(logger, helper, config) {
+    function factoryTypeScriptPreprocessor(logger, helper, config, basePath) {
         
         var _                = helper._;
         
@@ -80,7 +80,8 @@ module.exports = (function (testMode) {
         var log = logger.create('preprocessor:typescript')
         ,   _compiledBuffer  = []
         ,   _servedBuffer    = []
-        ,   tsProject        = ts.createProject(config.tsconfigPath, compilerOptions);
+        ,   tsconfigPath     = path.resolve(basePath, config.tsconfigPath)
+        ,   tsProject        = ts.createProject(tsconfigPath, compilerOptions);
         
         function compile() {
             if(dontCompile)return;
@@ -211,7 +212,7 @@ module.exports = (function (testMode) {
         }
     }
 
-    factoryTypeScriptPreprocessor.$inject = ['logger', 'helper', 'config.typescriptPreprocessor'];
+    factoryTypeScriptPreprocessor.$inject = ['logger', 'helper', 'config.typescriptPreprocessor', 'config.basePath'];
 
     return {
         'preprocessor:typescript': ['factory', factoryTypeScriptPreprocessor]

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = (function (testMode) {
     
     
     var ts          = require('gulp-typescript')
+    ,   sourcemaps  = require('gulp-sourcemaps')
     ,   Writable    = require('stream').Writable
     ,   path        = require("path")
     ,   typescript = isInTestMode? require('typescript'):undefined;//gulp-typescript bug
@@ -90,7 +91,9 @@ module.exports = (function (testMode) {
             _compiledBuffer = [];
             
             var output      = Writable({ objectMode: true }),
-                tsResult    = tsProject.src().pipe(ts(tsProject));
+                tsResult    = tsProject.src()
+                    .pipe(sourcemaps.init())
+                    .pipe(ts(tsProject));
 
             // save compiled files in memory 
             output._write   = function (chunk, enc, next) {
@@ -98,7 +101,10 @@ module.exports = (function (testMode) {
                 next();
             };
 
-            tsResult.js.pipe(output);
+            tsResult.js
+                .pipe(sourcemaps.write(config.sourcemapOptions || {}))
+                .pipe(output);
+
             //called at the end of compilation process
             tsResult.js.on('end', function () {
                 log.debug('Compilation completed!');

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "typescript": "1.6.2"
   },
   "dependencies": {
+    "gulp-sourcemaps": "^1.6.0",
     "gulp-typescript": "^2.9.2"
   },
   "repository": {


### PR DESCRIPTION
Sourcemaps are needed when testing Typescript code that must be transpiled to Javascript. The gulp-typescript compiler plugin ignores the sourcemap specifications in the tsconfig and compile options. This change enables sourcemaps generation using the gulp-sourcemaps plugin. The defaults create internal sourcemaps with source content which is adequate for testing.

Also added a change to make the tsconfigPath relative to the Karma basePath configuration value.
